### PR TITLE
Make links unclickable in emails (don't merge)

### DIFF
--- a/ui/src/viewers/EmailViewer.scss
+++ b/ui/src/viewers/EmailViewer.scss
@@ -22,5 +22,10 @@
       border: 0;
       box-shadow: unset;
     }
+
+    a {
+      pointer-events: none;
+      cursor: default;
+   }
   }
 }


### PR DESCRIPTION
In Documents, CSVs, Excels etc. a user can not click links.

This PR makes this consistent with emails. When viewing an email in OpenAleph, a user will see links rendered in their usual blue font style, but they will not be click-able.

This is achieved by adding a new CSS style in the email body SCSS.

**Do not merge** this unless all OpenAleph instances are meant to have this behaviour!
